### PR TITLE
Add runtime context interfaces and interface-based session tests

### DIFF
--- a/HQDotNet-Core-Test/HQSessionTest.cs
+++ b/HQDotNet-Core-Test/HQSessionTest.cs
@@ -262,5 +262,31 @@ namespace HQDotNet.Test {
             Assert.IsNull(_session.GetController<DummyModuleController>());
             Assert.IsFalse(dependentController.HasController());
         }
+
+        [Test]
+        public void RuntimeContextInterface_RegisterAndLookupController_Works() {
+            IHQRuntimeContext runtimeContext = new HQSession();
+
+            var controller = runtimeContext.RegisterController<DummyModuleController>();
+            var lookup = runtimeContext.GetController<DummyModuleController>();
+
+            Assert.NotNull(controller);
+            Assert.AreSame(controller, lookup);
+
+            (runtimeContext as HQSession).Shutdown();
+        }
+
+        [Test]
+        public void RuntimeContextInterface_RegisterAndLookupService_Works() {
+            IHQRuntimeContext runtimeContext = new HQSession();
+
+            var service = runtimeContext.RegisterService<DummyModuleService>();
+            var lookup = runtimeContext.GetService<DummyModuleService>();
+
+            Assert.NotNull(service);
+            Assert.AreSame(service, lookup);
+
+            (runtimeContext as HQSession).Shutdown();
+        }
     }
 }

--- a/HQDotNet-Core/Controller/HQSession.cs
+++ b/HQDotNet-Core/Controller/HQSession.cs
@@ -9,7 +9,7 @@ namespace HQDotNet {
     /// The three primary classes that are regulated here are <see cref="HQInjector"/>, <see cref="HQRegistry"/>, and <see cref="HQDispatcher"/>
     /// </summary>
     /// 
-    public class HQSession : HQCoreBehavior{
+    public class HQSession : HQCoreBehavior, IHQRuntimeContext{
         /// <summary>
         /// Dispatcher is responsible for observing registered classes' interface implementation and delivering messages accordingly
         /// </summary>
@@ -60,6 +60,7 @@ namespace HQDotNet {
         /// The current session instance's Dispatcher. Used for circulating messages throughout the app
         /// </summary>
         public HQDispatcher Dispatcher { get { return _dispatcher; } }
+        IHQDispatcher IHQRuntimeContext.Dispatcher { get { return _dispatcher; } }
 
         /// <summary>
         /// Create, inject, and register a singleton behavior for a type of Controller 
@@ -329,4 +330,3 @@ namespace HQDotNet {
 
     }
 }
-

--- a/HQDotNet-Core/Core/HQDispatcher.cs
+++ b/HQDotNet-Core/Core/HQDispatcher.cs
@@ -18,15 +18,15 @@ namespace HQDotNet
      * 
      */
 
-    public sealed class HQDispatcher : HQCoreBehavior{
+    public sealed class HQDispatcher : HQCoreBehavior, IHQDispatcher{
 
         //TODO: Dispatcher should queue up all dispatches to be executed in a (new) LateUpdate method.
         //Any other threads that need to dispatch should register here and will be dispatched later
         //What sort of design implications does this have?
 
         //It would be nice for these to also be immediately injectable.[HQInject]
-        private HQRegistry _registry;
-        public void SetRegistry(HQRegistry registry) {
+        private IHQRegistry _registry;
+        public void SetRegistry(IHQRegistry registry) {
             _registry = registry;
         }
 

--- a/HQDotNet-Core/Core/HQInjector.cs
+++ b/HQDotNet-Core/Core/HQInjector.cs
@@ -11,14 +11,14 @@ namespace HQDotNet
     /// HQInjector is the primary Dependency Injection class.
     /// This class scans newly registered <see cref="HQCoreBehavior"/> instances for the [HQInject] tag, and looks for appropriate object instances that match type.
     /// </summary>
-    public sealed class HQInjector : HQCoreBehavior{
+    public sealed class HQInjector : HQCoreBehavior, IHQInjector{
 
         //TODO: Injector flags in an injectormodel
         const BindingFlags INJECT_BINDING_FLAGS = BindingFlags.NonPublic | BindingFlags.Instance;
 
-        private HQRegistry _registry;
+        private IHQRegistry _registry;
 
-        public void SetRegistry(HQRegistry registry) {
+        public void SetRegistry(IHQRegistry registry) {
             _registry = registry;
         }
 

--- a/HQDotNet-Core/Core/HQRegistry.cs
+++ b/HQDotNet-Core/Core/HQRegistry.cs
@@ -10,7 +10,7 @@ using HQDotNet.Model;
  */
 
 namespace HQDotNet {
-    public sealed class HQRegistry : HQCoreBehavior{
+    public sealed class HQRegistry : HQCoreBehavior, IHQRegistry{
 
         public Dictionary<Type, HQController> Controllers { get; private set; }
         public Dictionary<Type, HQService> Services { get; private set; }

--- a/HQDotNet-Core/Core/IHQDispatcher.cs
+++ b/HQDotNet-Core/Core/IHQDispatcher.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace HQDotNet {
+    public interface IHQDispatcher {
+        void SetRegistry(IHQRegistry registry);
+        void RegisterDispatchListenersForObject(object listenerObject);
+        void UnregisterDispatchListenerInterface<TListener>(TListener behavior) where TListener : IDispatchListener;
+        List<TListener> GetListeners<TListener>() where TListener : IDispatchListener;
+        void UnregisterDispatchListenersForObject(object listenerObject);
+        void Dispatch<TDispatchListener>(Action<TDispatchListener> dispatchMessage) where TDispatchListener : IDispatchListener;
+    }
+}

--- a/HQDotNet-Core/Core/IHQInjector.cs
+++ b/HQDotNet-Core/Core/IHQInjector.cs
@@ -1,0 +1,8 @@
+namespace HQDotNet {
+    public interface IHQInjector {
+        void SetRegistry(IHQRegistry registry);
+        bool Inject(HQCoreBehavior behavior);
+        void UninjectBehavior(HQCoreBehavior behavior);
+        void ValidateInjectionRules(HQCoreBehavior behaviorToInject);
+    }
+}

--- a/HQDotNet-Core/Core/IHQRegistry.cs
+++ b/HQDotNet-Core/Core/IHQRegistry.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace HQDotNet {
+    public interface IHQRegistry {
+        Dictionary<Type, HQController> Controllers { get; }
+        Dictionary<Type, HQService> Services { get; }
+        Dictionary<Type, List<HQView>> Views { get; }
+
+        bool RegisterController<TBehavior>(TBehavior controller) where TBehavior : HQController, new();
+        bool RegisterService<TBehavior>(TBehavior service) where TBehavior : HQService, new();
+        bool RegisterView<TBehavior>(TBehavior view) where TBehavior : HQView, new();
+        void Unregister(HQCoreBehavior behavior);
+
+        void BindListener(Type type, object listenerObject);
+        void UnbindBehaviorListenerForObject<TListenerBehavior>(TListenerBehavior behavior) where TListenerBehavior : IDispatchListener;
+        void UnbindBehaviorListenerForObject(Type listenerType, IDispatchListener listener);
+        List<TDispatchListener> GetDispatchListenersForType<TDispatchListener>() where TDispatchListener : IDispatchListener;
+    }
+}

--- a/HQDotNet-Core/Core/IHQRuntimeContext.cs
+++ b/HQDotNet-Core/Core/IHQRuntimeContext.cs
@@ -1,0 +1,10 @@
+namespace HQDotNet {
+    public interface IHQRuntimeContext : IHQScope {
+        System.DateTime StartDate { get; }
+        System.TimeSpan TimeSinceStarted { get; }
+        IHQDispatcher Dispatcher { get; }
+
+        TBehavior GetService<TBehavior>() where TBehavior : HQService;
+        TBehavior GetController<TBehavior>() where TBehavior : HQController;
+    }
+}

--- a/HQDotNet-Core/Core/IHQScope.cs
+++ b/HQDotNet-Core/Core/IHQScope.cs
@@ -1,0 +1,11 @@
+namespace HQDotNet {
+    public interface IHQScope {
+        TBehavior RegisterController<TBehavior>() where TBehavior : HQController, new();
+        TBehavior RegisterService<TBehavior>() where TBehavior : HQService, new();
+        TBehavior RegisterView<TBehavior>() where TBehavior : HQView, new();
+
+        void RegisterObjectOnlyForDispatch(object obj);
+        void UnregisterNonHQBehaviorDispatch(object obj);
+        void Unregister(HQCoreBehavior behavior);
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce small, focused interfaces to decouple core runtime pieces (dispatcher, registry, injector, and session runtime scope) so other code and Unity integration can depend on abstractions instead of concrete types.
- Extract only the currently-used / test-required members from `HQDispatcher`, `HQRegistry`, `HQInjector`, and `HQSession` to keep the API minimal and safe for refactors.
- Provide a way to instantiate and exercise a session through an interface (`IHQRuntimeContext`) so runtime consumers can be written against the abstraction.

### Description

- Added new interfaces under `HQDotNet-Core/Core/`: `IHQDispatcher`, `IHQRegistry`, `IHQInjector`, `IHQScope`, and `IHQRuntimeContext` with the minimal members required by tests and runtime integration.
- Updated `HQDispatcher`, `HQRegistry`, and `HQInjector` to implement their respective interfaces and changed internal registry dependencies to use `IHQRegistry` instead of the concrete `HQRegistry`.
- Updated `HQSession` to implement `IHQRuntimeContext` and added an explicit interface implementation for `IHQRuntimeContext.Dispatcher` so the public `HQDispatcher Dispatcher` API is unchanged.
- Added two regression tests in `HQDotNet-Core-Test/HQSessionTest.cs` that instantiate `HQSession` via `IHQRuntimeContext` and validate `RegisterController`/`GetController` and `RegisterService`/`GetService` through the interface.

### Testing

- Added compile-level tests that exercise `IHQRuntimeContext` usage via `HQSession` by adding `RuntimeContextInterface_RegisterAndLookupController_Works` and `RuntimeContextInterface_RegisterAndLookupService_Works` to `HQSessionTest`.
- Attempted to run the test suite with `dotnet test HQDotNet-Core-Test/HQDotNet-Core-Test.csproj`, but the test runner could not be executed in this environment because `dotnet` is not installed (error: `/bin/bash: dotnet: command not found`).
- The changes are small and limited to interface extraction and explicit interface wiring; running the test suite in a proper .NET environment is recommended to validate runtime behavior and compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6bf41ee28832188d7026081f7337a)