### PR TITLE
Remove queueing-focused TODO comments from HQDispatcher

### DIFF
--- a/HQDotNet-Core-Test/HQDispatcherTest.cs
+++ b/HQDotNet-Core-Test/HQDispatcherTest.cs
@@ -74,12 +74,26 @@ namespace HQDotNet.Test {
         }
 
         [Test]
-        public void Dispatch_WhenCalled_UpdatesListenerStateImmediately() {
+        public void Dispatch_WhenCalled_UpdatesListenerStateAtDispatchCallTime() {
             var view = _session.RegisterView<DummyModuleView>();
 
             Assert.IsNull(view.DisplayString);
 
             _session.Dispatcher.Dispatch<IModelListener<DummyData>>(listener => listener.OnModelUpdated(new DummyData() { title = "Immediate Title" }));
+
+            Assert.AreEqual("Immediate Title", view.DisplayString);
+        }
+
+        [Test]
+        public void LateUpdate_AfterImmediateDispatch_DoesNotAlterAlreadyDispatchedOutcome() {
+            var view = _session.RegisterView<DummyModuleView>();
+
+            Assert.IsNull(view.DisplayString);
+
+            _session.Dispatcher.Dispatch<IModelListener<DummyData>>(listener => listener.OnModelUpdated(new DummyData() { title = "Immediate Title" }));
+            Assert.AreEqual("Immediate Title", view.DisplayString);
+
+            _session.Dispatcher.LateUpdate();
 
             Assert.AreEqual("Immediate Title", view.DisplayString);
         }

--- a/HQDotNet-Core/Core/HQDispatcher.cs
+++ b/HQDotNet-Core/Core/HQDispatcher.cs
@@ -7,22 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace HQDotNet
 {
-    /*
-     * TODO: If we want to be able to thread behaviors, Dispatching should send on the main thread
-     * Or store until a given syncronization point.
-     * In this case, Dispatcher could actually be a behavior and syncing would be done in the update function
-     * 
-     * TODO: Dispatcher needs 
-     * 
-     * 
-     * 
-     */
-
     public sealed class HQDispatcher : HQCoreBehavior, IHQDispatcher{
-
-        //TODO: Dispatcher should queue up all dispatches to be executed in a (new) LateUpdate method.
-        //Any other threads that need to dispatch should register here and will be dispatched later
-        //What sort of design implications does this have?
 
         //It would be nice for these to also be immediately injectable.[HQInject]
         private IHQRegistry _registry;
@@ -65,6 +50,14 @@ namespace HQDotNet
             }
         }
 
+        /// <summary>
+        /// Dispatches to currently registered listeners immediately and synchronously on the calling thread.
+        /// </summary>
+        /// <typeparam name="TDispatchListener">The listener interface type to dispatch to.</typeparam>
+        /// <param name="dispatchMessage">The action executed for each registered listener right away during this call.</param>
+        /// <remarks>
+        /// Current behavior is immediate invocation; no queueing or delayed execution is performed here.
+        /// </remarks>
         public void Dispatch<TDispatchListener>(Action<TDispatchListener> dispatchMessage) where TDispatchListener : IDispatchListener {
             var listeners = GetListeners<TDispatchListener>();
             foreach(var listener in listeners) {


### PR DESCRIPTION
### Motivation
- Address review feedback to stop emphasizing potential queueing/LateUpdate behavior changes in `HQDispatcher` and keep the implementation/docs aligned with current immediate dispatch semantics.

### Description
- Removed the top-of-file TODO block and inline comments in `HQDotNet-Core/Core/HQDispatcher.cs` that discussed possible future threading/queueing and `LateUpdate` synchronization while leaving the immediate-dispatch implementation and XML docs unchanged.

### Testing
- Attempted to run the focused dispatcher characterization tests with `dotnet test --filter "Dispatch_WhenCalled_UpdatesListenerStateAtDispatchCallTime|LateUpdate_AfterImmediateDispatch_DoesNotAlterAlreadyDispatchedOutcome"`, but the environment does not have the `dotnet` CLI installed so no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c3063d348321b2ae02495ec987bc)