### PR TITLE
Introduce HQContextRootMonoBehaviour for view binding and deprecate HQViewMediator with compatibility

### DIFF
--- a/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Scripts/Util/HQContextRootMonoBehaviour.cs
+++ b/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Scripts/Util/HQContextRootMonoBehaviour.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+
+namespace HQDotNet.Unity {
+    /// <summary>
+    /// Provides the active HQSession context to HQMonoView instances and can bind discovered views.
+    /// </summary>
+    public class HQContextRootMonoBehaviour : MonoBehaviour {
+        public static HQContextRootMonoBehaviour Active { get; private set; }
+
+        private static HQSession _legacySession;
+
+        private HQSession _session;
+
+        public HQSession Session => _session;
+
+        public static bool TryGetActive(out HQContextRootMonoBehaviour contextRoot) {
+            contextRoot = Active;
+            return contextRoot != null;
+        }
+
+        internal static void SetLegacySession(HQSession session) {
+            _legacySession = session;
+        }
+
+        internal static void ClearLegacySession() {
+            _legacySession = null;
+        }
+
+        internal static bool TryGetLegacySession(out HQSession session) {
+            session = _legacySession;
+            return session != null;
+        }
+
+        public virtual void Initialize(HQSession session, bool bindDiscoveredViews = true) {
+            _session = session;
+            Active = this;
+
+            if (bindDiscoveredViews) {
+                BindDiscoveredViews();
+            }
+        }
+
+        public virtual void Shutdown() {
+            if (Active == this) {
+                Active = null;
+            }
+
+            _session = null;
+        }
+
+        public virtual bool RegisterMonoView(HQMonoView monoView) {
+            if (_session == null || monoView == null) {
+                return false;
+            }
+
+            monoView.SetSession(_session);
+            return true;
+        }
+
+        public virtual void BindDiscoveredViews() {
+            var views = FindObjectsOfType<HQMonoView>(true);
+            foreach (var view in views) {
+                RegisterMonoView(view);
+            }
+        }
+    }
+}

--- a/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Scripts/Util/HQContextRootMonoBehaviour.cs.meta
+++ b/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Scripts/Util/HQContextRootMonoBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68afcd9205cd449486b2e4cb79fb70e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Scripts/Util/HQSessionSetupMonoBehavior.cs
+++ b/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Scripts/Util/HQSessionSetupMonoBehavior.cs
@@ -3,15 +3,17 @@ using UnityEngine;
 namespace HQDotNet.Unity {
     public class HQSessionSetupMonoBehavior : MonoBehaviour {
         protected HQSession _session;
+        protected HQContextRootMonoBehaviour _contextRoot;
 
         public virtual void Awake() {
             _session = new HQSession();
-            HQViewMediator.CreateInstance(_session);
-            MainThreadSyncer.CreateInstance();
-            var views = FindObjectsOfType<HQMonoView>(true);
-            foreach(var view in views) {
-                view.SetSession(_session);
+            _contextRoot = GetComponent<HQContextRootMonoBehaviour>();
+            if (_contextRoot == null) {
+                _contextRoot = gameObject.AddComponent<HQContextRootMonoBehaviour>();
             }
+
+            _contextRoot.Initialize(_session);
+            MainThreadSyncer.CreateInstance();
         }
 
         public virtual void Start() {
@@ -33,11 +35,16 @@ namespace HQDotNet.Unity {
         public virtual void OnDestroy() {
             if(MainThreadSyncer.Instance != null)
                 MainThreadSyncer.DestroyInstance();
-            if(HQViewMediator.Instance != null)
-                HQViewMediator.DestroyInstance();
+
+            if (_contextRoot != null) {
+                _contextRoot.Shutdown();
+            }
+
             if (_session != null)
                 _session.Shutdown();
+
             _session = null;
+            _contextRoot = null;
         }
 
         public virtual void OnApplicationQuit() {

--- a/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Scripts/Util/HQViewMediator.cs
+++ b/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Scripts/Util/HQViewMediator.cs
@@ -1,25 +1,32 @@
-using System.Collections;
-using System.Collections.Generic;
+using System;
 using UnityEngine;
 
 namespace HQDotNet.Unity {
+    [Obsolete("HQViewMediator is deprecated. Use HQContextRootMonoBehaviour instead.")]
     public class HQViewMediator {
         public static HQViewMediator Instance { get; private set; }
         private HQSession _session;
 
+        [Obsolete("HQViewMediator is deprecated. Use HQContextRootMonoBehaviour instead.")]
         public static void CreateInstance(HQSession session) {
             Instance = new HQViewMediator(session);
+            HQContextRootMonoBehaviour.SetLegacySession(session);
         }
 
+        [Obsolete("HQViewMediator is deprecated. Use HQContextRootMonoBehaviour instead.")]
         public static void DestroyInstance() {
+            HQContextRootMonoBehaviour.ClearLegacySession();
             Instance = null;
         }
 
+        [Obsolete("HQViewMediator is deprecated. Use HQContextRootMonoBehaviour instead.")]
         public HQViewMediator(HQSession session) {
             Instance = this;
             _session = session;
+            HQContextRootMonoBehaviour.SetLegacySession(session);
         }
 
+        [Obsolete("HQViewMediator is deprecated. Use HQContextRootMonoBehaviour instead.")]
         public void RegisterMonoView(HQMonoView monoView) {
             monoView.SetSession(_session);
         }

--- a/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Scripts/View/HQMonoView.cs
+++ b/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Scripts/View/HQMonoView.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using HQDotNet;
 
@@ -10,11 +8,21 @@ namespace HQDotNet.Unity
         protected HQSession _session;
 
         /// <summary>
-        /// If this view has not been registered with HQ yet, register it via the HQViewMediator
+        /// If this view has not been registered with HQ yet, register it via the active HQ context root.
+        /// Falls back to the legacy HQViewMediator compatibility path when needed.
         /// </summary>
         protected virtual void Awake() {
-            if (HQViewMediator.Instance != null && _session == null) {
-                HQViewMediator.Instance.RegisterMonoView(this);
+            if (_session != null) {
+                return;
+            }
+
+            if (HQContextRootMonoBehaviour.TryGetActive(out var contextRoot)) {
+                contextRoot.RegisterMonoView(this);
+                return;
+            }
+
+            if (HQContextRootMonoBehaviour.TryGetLegacySession(out var legacySession)) {
+                SetSession(legacySession);
             }
         }
 

--- a/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Tests/Editor/HQViewBindingCompatibilityTests.cs
+++ b/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Tests/Editor/HQViewBindingCompatibilityTests.cs
@@ -1,0 +1,76 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace HQDotNet.Unity.Tests.Editor {
+    public class HQViewBindingCompatibilityTests {
+        private class TestableMonoView : HQMonoView {
+            public HQSession BoundSession => _session;
+
+            public void InvokeAwake() {
+                base.Awake();
+            }
+        }
+
+        private class TestableSessionSetup : HQSessionSetupMonoBehavior {
+            public HQSession Session => _session;
+            public HQContextRootMonoBehaviour ContextRoot => _contextRoot;
+        }
+
+        [Test]
+        public void NewBindingMode_ActiveContextRootBindsViewDuringAwake() {
+            var session = new HQSession();
+            var contextObject = new GameObject("context-root");
+            var contextRoot = contextObject.AddComponent<HQContextRootMonoBehaviour>();
+            contextRoot.Initialize(session, false);
+
+            var viewObject = new GameObject("view");
+            var view = viewObject.AddComponent<TestableMonoView>();
+            view.InvokeAwake();
+
+            Assert.AreSame(session, view.BoundSession);
+
+            contextRoot.Shutdown();
+            Object.DestroyImmediate(viewObject);
+            Object.DestroyImmediate(contextObject);
+        }
+
+        [Test]
+        public void NewBindingMode_SessionSetupProvidesContextRootAndBindsDiscoveredViews() {
+            var sessionSetupObject = new GameObject("session-setup");
+            var sessionSetup = sessionSetupObject.AddComponent<TestableSessionSetup>();
+
+            var viewObject = new GameObject("view");
+            var view = viewObject.AddComponent<TestableMonoView>();
+
+            sessionSetup.Awake();
+
+            Assert.IsNotNull(sessionSetup.ContextRoot);
+            Assert.IsNotNull(sessionSetup.Session);
+            Assert.AreSame(sessionSetup.Session, view.BoundSession);
+
+            sessionSetup.OnDestroy();
+            Object.DestroyImmediate(viewObject);
+            Object.DestroyImmediate(sessionSetupObject);
+        }
+
+        [Test]
+        public void LegacyBindingMode_ViewMediatorStillBindsView() {
+            var session = new HQSession();
+
+#pragma warning disable CS0618
+            HQViewMediator.CreateInstance(session);
+#pragma warning restore CS0618
+
+            var viewObject = new GameObject("legacy-view");
+            var view = viewObject.AddComponent<TestableMonoView>();
+            view.InvokeAwake();
+
+            Assert.AreSame(session, view.BoundSession);
+
+#pragma warning disable CS0618
+            HQViewMediator.DestroyInstance();
+#pragma warning restore CS0618
+            Object.DestroyImmediate(viewObject);
+        }
+    }
+}

--- a/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Tests/Editor/HQViewBindingCompatibilityTests.cs.meta
+++ b/HQDotNet-UnityPackage/Assets/HQDotNet.Unity/Tests/Editor/HQViewBindingCompatibilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c4161ee51da4d52bef97149b3f6e9d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Remove direct coupling between `HQMonoView` and the `HQViewMediator` singleton to enable a context-root provider flow and improve testability and flexibility.
- Provide a single authoritative owner for `HQSession` in Unity scenes so views can discover and bind to the session without relying on a global mediator.
- Preserve a compatibility path for existing code that still uses `HQViewMediator` while marking it deprecated to enable a gradual migration.

### Description
- Add `HQContextRootMonoBehaviour` (`Assets/HQDotNet.Unity/Scripts/Util/HQContextRootMonoBehaviour.cs`) that owns the active `HQSession`, exposes `TryGetActive`/`RegisterMonoView` and a legacy session hook for compatibility.
- Update `HQMonoView` (`Assets/HQDotNet.Unity/Scripts/View/HQMonoView.cs`) so `Awake()` first uses the active context root to register the view and falls back to the legacy-session path if present, removing direct `HQViewMediator.Instance` usage.
- Update `HQSessionSetupMonoBehavior` (`Assets/HQDotNet.Unity/Scripts/Util/HQSessionSetupMonoBehavior.cs`) to create/initialize a `HQContextRootMonoBehaviour` and bind discovered views instead of calling `HQViewMediator.CreateInstance`/`DestroyInstance`.
- Mark `HQViewMediator` APIs as `[Obsolete]` and forward legacy session state into the new context-root fallback so old code paths continue working during migration.
- Add editor NUnit tests (`Assets/HQDotNet.Unity/Tests/Editor/HQViewBindingCompatibilityTests.cs`) that cover new context-root binding during `Awake`, session-setup binding discovered views, and legacy mediator binding behavior.

### Testing
- Added editor NUnit tests for view-binding compatibility that exercise new and legacy binding modes in the Unity Editor test assembly and were committed with the change.
- Attempted to run `dotnet test HQDotNet-Core-Test/HQDotNet-Core-Test.csproj` in this environment but it failed because `dotnet` is not installed here, so no project-level `dotnet` tests were executed.
- Unity Editor playmode/editor tests were not executed in this CI environment, but the new tests are included for execution in a Unity Editor test runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c6e4ae6c8321841689164238547e)